### PR TITLE
Improve order summary features

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,13 +93,13 @@
     </div>
 
     <!-- Floating button to view order summary -->
-    <button id="viewOrderBtn" onclick="openOrderModal()" class="fixed bottom-6 right-6 bg-green-600 text-white rounded-full px-4 py-3 shadow-lg">
+    <button id="viewOrderBtn" onclick="openOrderModal()" class="fixed bottom-6 right-6 bg-green-600 text-white rounded-full px-4 py-3 shadow-lg transition-colors">
         ดูสรุป
     </button>
 
     <!-- Order summary modal -->
     <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div class="bg-white rounded-lg p-4 w-11/12 max-w-md" id="orderSummary">
+        <div class="bg-white rounded-lg p-4 w-11/12 max-w-lg max-h-[90vh] overflow-y-auto" id="orderSummary">
             <h2 class="text-lg font-bold text-center mb-2">สรุปออเดอร์</h2>
             <ul id="orderList" class="space-y-1 text-sm mb-2"></ul>
             <p id="orderTotal" class="font-medium text-right"></p>
@@ -113,7 +113,7 @@
 
     <!-- Toppings selection modal -->
     <div id="toppingsModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div class="bg-white rounded-lg p-4 w-11/12 max-w-sm">
+        <div class="bg-white rounded-lg p-4 w-11/12 max-w-sm max-h-[80vh] overflow-y-auto">
             <h2 class="text-lg font-bold text-center mb-2">เลือกท็อปปิ้ง</h2>
             <div id="toppingsList" class="space-y-1 text-sm mb-2"></div>
             <div class="mt-4 flex justify-end space-x-2">
@@ -455,6 +455,14 @@
         const order = [];
         let currentItemId = null;
 
+        function updateOrderButton() {
+            const btn = document.getElementById('viewOrderBtn');
+            const count = order.reduce((s, o) => s + o.qty, 0);
+            btn.textContent = count > 0 ? `ดูสรุป (${count})` : 'ดูสรุป';
+            btn.classList.toggle('bg-green-600', count === 0);
+            btn.classList.toggle('bg-red-500', count > 0);
+        }
+
         function openToppingsModal(id) {
             currentItemId = id;
             const container = document.getElementById('toppingsList');
@@ -483,7 +491,14 @@
         function addToOrder(id, selectedToppings) {
             const item = menuItems.find(i => i.id === id);
             if (!item) return;
-            order.push({ item: item, qty: 1, toppings: selectedToppings });
+            const key = id + '|' + selectedToppings.map(t => t.name).sort().join('|');
+            const existing = order.find(o => o.key === key);
+            if (existing) {
+                existing.qty += 1;
+            } else {
+                order.push({ key, item, qty: 1, toppings: selectedToppings });
+            }
+            updateOrderButton();
         }
 
         function openOrderModal() {
@@ -495,17 +510,55 @@
             document.getElementById('orderModal').classList.add('hidden');
         }
 
+        function increaseQty(index) {
+            order[index].qty += 1;
+            renderOrderList();
+            updateOrderButton();
+        }
+
+        function decreaseQty(index) {
+            if (order[index].qty > 1) {
+                order[index].qty -= 1;
+            } else {
+                if (confirm('ลบรายการนี้หรือไม่?')) {
+                    order.splice(index, 1);
+                }
+            }
+            renderOrderList();
+            updateOrderButton();
+        }
+
+        function removeOrder(index) {
+            if (confirm('ลบรายการนี้หรือไม่?')) {
+                order.splice(index, 1);
+                renderOrderList();
+                updateOrderButton();
+            }
+        }
+
         function renderOrderList() {
             const list = document.getElementById('orderList');
             const totalEl = document.getElementById('orderTotal');
             list.innerHTML = '';
             let total = 0;
-            order.forEach(({ item, qty, toppings }) => {
+            order.forEach(({ item, qty, toppings }, index) => {
                 const li = document.createElement('li');
                 const itemPrice = typeof item.price === 'number' ? item.price : 0;
                 const toppingPrice = (toppings || []).reduce((s, t) => s + t.price, 0);
                 const toppingText = (toppings || []).map(t => t.name).join(', ');
-                li.textContent = `${item.name}${toppingText ? ' [' + toppingText + ']' : ''} x${qty} ฿${(itemPrice + toppingPrice) * qty}`;
+                li.innerHTML = `
+                    <div class="flex justify-between items-center">
+                        <div>
+                            <span class="font-medium">${item.id}</span> ${item.name}${toppingText ? ' [' + toppingText + ']' : ''}
+                            <div class="text-xs text-gray-500">฿${itemPrice} + ฿${toppingPrice}</div>
+                        </div>
+                        <div class="flex items-center space-x-1">
+                            <button onclick="decreaseQty(${index})" class="px-2 bg-gray-200 rounded">-</button>
+                            <span>${qty}</span>
+                            <button onclick="increaseQty(${index})" class="px-2 bg-gray-200 rounded">+</button>
+                            <button onclick="removeOrder(${index})" class="px-2 text-red-600">×</button>
+                        </div>
+                    </div>`;
                 total += (itemPrice + toppingPrice) * qty;
                 list.appendChild(li);
             });
@@ -515,17 +568,21 @@
         function shareOrderText() {
             renderOrderList();
             const totalText = document.getElementById('orderTotal').textContent;
-            let text = 'สรุปออเดอร์\n';
+            let text = '📋 สรุปออเดอร์\n';
             order.forEach(({ item, qty, toppings }) => {
                 const toppingPrice = (toppings || []).reduce((s, t) => s + t.price, 0);
                 const itemPrice = typeof item.price === 'number' ? item.price : 0;
                 const priceText = `฿${(itemPrice + toppingPrice) * qty}`;
                 const toppingText = (toppings || []).map(t => t.name).join(', ');
-                text += `${item.name}${toppingText ? ' [' + toppingText + ']' : ''} x${qty} ${priceText}\n`;
+                text += `🔹 ${item.id} ${item.name}${toppingText ? ' [' + toppingText + ']' : ''} x${qty} ${priceText}\n`;
             });
-            text += totalText;
+            text += `💰${totalText}`;
             const encoded = encodeURIComponent(text);
-            window.location.href = `line://oaMessage/@kpnn/?${encoded}`;
+            if (/Line/i.test(navigator.userAgent)) {
+                window.location.href = `line://oaMessage/@kpnn/?${encoded}`;
+            } else {
+                navigator.clipboard.writeText(text).then(() => alert('คัดลอกสรุปแล้ว'));
+            }
         }
 
         function downloadOrderImage() {
@@ -625,6 +682,7 @@
         // Initial render when the page loads
         document.addEventListener('DOMContentLoaded', () => {
             displayMenuSections();
+            updateOrderButton();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- show item count on the order summary button and change its colour
- enlarge modals and allow scrolling
- allow adjusting order quantities and removing orders
- keep separate orders by topping and include product codes in shared text
- format share text with emoji and copy on desktop

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846930f3fc883299dde1f8e36bb3540