### PR TITLE
Implement simple admin backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+index.html.bak
+menuItems.txt

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ python3 -m http.server
 
 Then visit `http://localhost:8000/index.html`.
 
+### Running the Admin Backend
+
+The project includes a simple Express server for managing menu items. Install dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+By default the server runs on `http://localhost:3000`. Access the admin page at `http://localhost:3000/admin`. The default username is `admin` and the password can be set via the `ADMIN_PASS` environment variable (defaults to `changeme`).
+
 ## Dependencies
 
 The menu relies on external CDN links for styling and screenshot support:

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Panel</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-xl font-bold mb-4">จัดการเมนู</h1>
+  <table id="items" class="min-w-full border-collapse"></table>
+  <script>
+    async function load() {
+      const res = await fetch('/api/menu-items');
+      const items = await res.json();
+      const rows = items.map(item => `
+        <tr class="border-b">
+          <td class="p-2">${item.id}</td>
+          <td class="p-2"><input value="${item.name}" data-id="${item.id}" data-field="name" class="border px-1"/></td>
+          <td class="p-2"><input value="${item.price}" data-id="${item.id}" data-field="price" class="border px-1 w-20"/></td>
+          <td class="p-2"><input value="${item.description}" data-id="${item.id}" data-field="description" class="border px-1"/></td>
+          <td class="p-2"><select data-id="${item.id}" data-field="status" class="border px-1">
+            <option value="พร้อมจำหน่าย" ${item.status === 'พร้อมจำหน่าย' ? 'selected' : ''}>พร้อมจำหน่าย</option>
+            <option value="ยังไม่พร้อมจำหน่าย" ${item.status === 'ยังไม่พร้อมจำหน่าย' ? 'selected' : ''}>ยังไม่พร้อมจำหน่าย</option>
+          </select></td>
+          <td class="p-2"><button data-id="${item.id}" class="save px-2 bg-blue-500 text-white rounded">บันทึก</button></td>
+        </tr>
+      `).join('');
+      document.getElementById('items').innerHTML = rows;
+    }
+
+    document.addEventListener('click', async e => {
+      if (e.target.classList.contains('save')) {
+        const id = e.target.dataset.id;
+        const inputs = document.querySelectorAll(`[data-id="${id}"]`);
+        const body = {};
+        inputs.forEach(i => body[i.dataset.field] = i.value);
+        await fetch('/api/menu-items/' + id, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+        alert('บันทึกแล้ว');
+      }
+    });
+
+    load();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -159,310 +159,26 @@
     </div>
 
     <script>
-        // Hardcoded menu items data based on the provided image, ordered by category and ID.
-        // Descriptions are based on previous content or general understanding if not specified.
-        const menuItems = [
-            // Category: กะเพรา | 打抛饭
-            {
-                id: 'A10',
-                name: 'กะเพราหมูสับ',
-                chineseName: '打拋猪肉末飯',
-                price: 60,
-                category: 'กะเพรา | 打抛饭',
-                description: 'หมูสับผัดร้อนกับพริกและกระเพรา รสชาติจัดจ้าน หอมกลิ่นกระเพรา',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829081858/photos/90c609683c5746bbb33c07d09e706a0b_1749291509094445301.jpeg',
-            },
-            {
-                id: 'A20',
-                name: 'กะเพราหมูชิ้น',
-                chineseName: '打拋猪肉片飯',
-                price: 60,
-                category: 'กะเพรา | 打抛饭',
-                description: 'หมูชิ้นสไลซ์หนา ผัดกับพริกขี้หนูและกระเพรา เพิ่มรสเผ็ดร้อนเค็มกลมกล่อม',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101828075733/photos/a1c15920c62744bb87f0add8dc9b240b_1749291508901628367.jpeg',
-            },
-            {
-                id: 'A30',
-                name: 'กะเพราเนื้อสับ ดรายเอจพรีเมียม',
-                chineseName: '优质干式熟成罗勒牛肉碎',
-                price: 99,
-                category: 'กะเพรา | 打抛饭',
-                description: 'กะเพราเนื้อสับ ดรายเอจพรีเมียม รสเข้มข้น ให้รสชาติเนื้อเนียน ๆ ผสานความเผ็ดร้อนและกลิ่นหอมของใบกะเพรา',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829098489/photos/3304eaf7086c44ca8160d9a35e1bdb7c_1749291509277542087.jpeg',
-            },
-            {
-                id: 'A40',
-                name: 'กะเพรากุ้ง',
-                chineseName: '打拋虾仁飯',
-                price: 65,
-                category: 'กะเพรา | 打拋饭',
-                description: 'กุ้งสดเด้งผัดกับพริกขี้หนูและกระเพรา มอบรสเผ็ดร้อนและกลิ่นหอมของสมุนไพรไทย',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829103154/photos/e50bc49d0bad4c69b45aa0930583e692_1749291509433736279.jpeg',
-            },
-            {
-                id: 'A50',
-                name: 'กะเพราหมึก',
-                chineseName: '打拋鱿鱼飯',
-                price: 65,
-                category: 'กะเพรา | 打抛饭',
-                description: 'หมึกสดกรอบผัดกระเพรารสจัด ราดด้วยน้ำมันหอยเล็กน้อย เพิ่มรสกลมกล่อมและความหอมของกระเพรา',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829112940/photos/cf4cac4a97404815b6f68d57a716dcdb_1749291509586307764.jpeg',
-            },
-            {
-                id: 'A60',
-                name: 'กะเพราทะเลรวม',
-                chineseName: '打拋海鮮飯',
-                price: 65,
-                category: 'กะเพรา | 打抛饭',
-                description: 'รวมซีฟู้ดสด ทั้งกุ้ง หมึก และหอย ปรุงรสเข้มข้นกับพริกและกระเพรา ให้รสชาติทะเลหอมกรุ่น',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829120496/photos/a537449c0c79412a9446f4dc938e1724_1749291509766172777.jpeg',
-            },
+    let menuItems = [];
+    const toppings = [
+        { name: "ไข่ดาว", price: 10 },
+        { name: "ไข่เจียว", price: 10 },
+        { name: "ไข่ข้น สองฟอง", price: 20 }
+    ];
 
-            // Category: สปาเก็ตตี้กะเพรา | 蒜蓉炒意面
-            {
-                id: 'B10',
-                name: 'สปาเก็ตตี้กะเพราหมูสับ',
-                chineseName: '蒜蓉猪肉末意面',
-                price: 129,
-                category: 'สปาเก็ตตี้กะเพรา | 蒜蓉炒意面',
-                description: 'เส้นสปาเก็ตตี้ผัดกับหมูสับและกระเพรา รสจัด เผ็ดร้อน เคล้ากลิ่นหอมของสมุนไพร',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830142460/photos/c2358496f1f44fa99d8ef8fec16e70c6_1749291510140832547.jpeg',
-            },
-            {
-                id: 'B20',
-                name: 'สปาเก็ตตี้กะเพราเบคอน',
-                chineseName: '蒜蓉培根意面',
-                price: 139,
-                category: 'สปาเก็ตตี้กะเพรา | 蒜蓉炒意面',
-                description: 'สปาเก็ตตี้เส้นเหนียวนุ่ม ผัดกับเบคอนกรอบพริกขี้หนูและใบกะเพรา รสจัดจ้านกลมกล่อม',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830136048/photos/c5c13942080f4163933307f52a24b219_1749291510017200586.jpeg',
-            },
-            {
-                id: 'B30',
-                name: 'สปาเก็ตตี้กะเพราเนื้อสับ',
-                chineseName: '牛肉蒜蓉意大利面',
-                price: 139,
-                category: 'สปาเก็ตตี้กะเพรา | 蒜蓉炒意面',
-                description: 'เส้นสปาเก็ตตี้ผัดกับเนื้อสับพริกขี้หนูและกระเพรา มอบรสจัดจ้านและกลิ่นหอมของสมุนไพรไทย',
-                image: 'https://food-cms.grab.com/compressed_webp/items/THITE2025060818072098264/detail/menueditor_item_613b0d3e16594075b7d491c80468f182_1749405805842677085.webp', // Updated image URL
-            },
-            {
-                id: 'B40',
-                name: 'สปาเก็ตตี้กะเพรากุ้ง',
-                chineseName: '蒜蓉虾仁意面',
-                price: 139,
-                category: 'สปาเก็ตตี้กะเพรา | 蒜蓉炒意面',
-                description: 'เส้นสปาเก็ตตี้ผัดกับกุ้งสดพริกขี้หนูและกระเพรา มอบรสจัดจ้านและกลิ่นหอมทะเล',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830155451/photos/3ec3d4b3b22f47c09c9c03317276e98e_1749291510388832728.jpeg',
-            },
-            {
-                id: 'B50',
-                name: 'สปาเก็ตตี้กะเพราหมึก',
-                chineseName: '蒜蓉鱿鱼意面',
-                price: 139,
-                category: 'สปาเก็ตตี้กะเพรา | 蒜蓉炒意面',
-                description: 'สปาเก็ตตี้คลุกเคล้ากับหมึกสดและกระเพรา รสจัดจ้าน หวานนิดเค็มหน่อย กลิ่นหอมสมุนไพร',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830162409/photos/38258fab3cb74ebaa3299207a82d771a_1749291510584447361.jpeg',
-            },
-            {
-                id: 'B60',
-                name: 'สปาเก็ตตี้กะเพราทะเลรวม',
-                chineseName: '蒜蓉海鲜意面',
-                price: 139,
-                category: 'สปาเก็ตตี้กะเพรา | 蒜蓉炒意面',
-                description: 'สปาเก็ตตี้รวมซีฟู้ด ผัดกะเพรารสจัด เคล้ากลิ่นหอมทะเลและใบกะเพรา',
-                image: 'https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830178652/photos/5a329a1bfb644082a5daaf70f56c6b95_1749291510756808485.jpeg',
-            },
+    let searchTerm = '';
+    const order = [];
+    let currentItemId = null;
 
-            // Category: ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭
-            {
-                id: 'C10',
-                name: 'ข้าวไข่ข้นหมูชิ้นทอดกระเทียม',
-                chineseName: '蒜蓉滑蛋配香脆猪肉片',
-                price: 79,
-                category: 'ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭',
-                description: 'ข้าวหอมมะลิ นุ่มราดด้วยไข่ข้นเนียน ๆ ท็อปด้วยหมูชิ้นทอดกรอบ ราดด้วยกระเทียมเจียวหอม ๆ ให้รสกลมกล่อมลงตัว',
-                image: 'https://food-cms.grab.com/item/THITE20250607101827015838/photos/5cb10df83786464b9991a95331cf22a6_1749291507846057663.jpeg',
-            },
-            {
-                id: 'C20',
-                name: 'ข้าวไข่ข้นหมูสับทอดกระเทียม',
-                chineseName: '蒜蓉滑蛋配猪肉末',
-                price: 79,
-                category: 'ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭',
-                description: 'ข้าวหอมมะลิ่นุ่มราดไข่ข้นลื่นกลมกล่อม เสิร์ฟพร้อมหมูสับทอดกระเทียมหอมกรอบ เพิ่มมิติความอร่อย',
-                image: 'https://food-cms.grab.com/item/THITE20250607101827023617/photos/4918d7e8f5e74775be9ad61febd36ce9_1749291508000517172.jpeg',
-            },
-            {
-                id: 'C30',
-                name: 'ข้าวไข่ข้นสามชั้นทอดกระเทียม',
-                chineseName: '蒜蓉滑蛋配五花肉',
-                price: 85,
-                category: 'ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭',
-                description: 'ข้าวหอมมะลิร้อน ๆ ราดไข่ข้นเนียนนุ่ม พร้อมสามชั้นหมูทอดกระเทียมกรอบมัน ผสมผสานรสเค็มหวานอย่างลงตัว',
-                image: 'https://food-cms.grab.com/item/THITE20250607101828030835/photos/f839283ea70146cd9df90660a0602395_1749291508172427363.jpeg',
-            },
-            {
-                id: 'C40',
-                name: 'ข้าวไข่ข้นเบคอนทอดกระเทียม',
-                chineseName: '蒜蓉滑蛋配培根',
-                price: 85,
-                category: 'ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭',
-                description: 'ไข่ข้นเนื้อเนียนราดบนข้าวหอมมะลิ เสิร์ฟพร้อมเบคอนทอดกรอบ ราดกระเทียมเจียวหอมฉุย',
-                image: 'https://food-cms.grab.com/item/THITE20250607101828047027/photos/e67d20f2366e4fe09065b6651b8426a7_1749291508291199328.jpeg',
-            },
-            {
-                id: 'C50',
-                name: 'ข้าวไข่ข้นกุ้งทอดกระเทียม',
-                chineseName: '蒜蓉滑蛋配虾仁',
-                price: 85,
-                category: 'ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭',
-                description: 'ไข่ข้นเนียนลื่นผสานบนข้าวหอมมะลิ เสิร์ฟพร้อมกุ้งทอดกระเทียม ให้รสชาติหวานมันเค็มกรอบอย่างลงตัว',
-                image: 'https://food-cms.grab.com/item/THITE20250607101828059916/photos/64b3a1c4348c48acad1c5bef0602b09c_1749291508460521618.jpeg',
-            },
-            {
-                id: 'C60',
-                name: 'ข้าวไข่ข้นหมึกทอดกระเทียม',
-                chineseName: '蒜蓉滑蛋配鱿鱼',
-                price: 85,
-                category: 'ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭',
-                description: 'ข้าวหอมมะลิร้อน ๆ กับไข่ข้นเนียนนุ่ม ท็อปด้วยหมึกทอดกระเทียมหอมกรอบ มอบประสบการณ์รสชาติใหม่',
-                image: 'https://food-cms.grab.com/compressed_webp/items/THITE20250607101828064013/detail/d20f4774f46c4aefa51fce242bee0f80_1749291508736290122.webp', // Updated image URL
-            },
-
-            // Category: ข้าวห่อหมกไข่ข้น | 咖喱滑蛋饭
-            {
-                id: 'E10',
-                name: 'ข้าวห่อหมกไข่ข้นทะเล',
-                chineseName: '咖喱滑蛋配海鲜咖喱饭',
-                price: 85,
-                category: 'ข้าวห่อหมกไข่ข้น | 咖喱滑蛋饭',
-                description: 'ข้าวหอมมะลิห่อด้วยไข่ข้น สอดไส้ทะเลรวม หวานมัน เผ็ดกลมกล่อม ได้กลิ่นเครื่องแกงใต้',
-                image: 'https://food-cms.grab.com/item/THITE20250607101831205466/photos/fd78335aab7d47f786e53bf3d46bbe8f_1749291511304272485.jpeg',
-            },
-            {
-                id: 'E20',
-                name: 'ข้าวห่อหมกไข่ข้นกุ้ง',
-                chineseName: '咖喱滑蛋配虾仁咖喱饭',
-                price: 85,
-                category: 'ข้าวห่อหมกไข่ข้น | 咖喱滑蛋饭',
-                description: 'ข้าวหอมมะลิห่อด้วยไข่ข้นห่อด้วยไข่ข้นรสเข้ม เสิร์ฟพร้อมห่อหมกกุ้งเนื้อแน่น เผ็ดนิด ๆ หวานมัน',
-                image: 'https://food-cms.grab.com/item/THITE20250607101830184557/photos/73a40c4bbd5c4ee29db93587ec2cac7a_1749291510941373744.jpeg',
-            },
-            {
-                id: 'E30',
-                name: 'ข้าวห่อหมกไข่ข้นหมึก',
-                chineseName: '咖喱滑蛋配鱿鱼咖喱饭',
-                price: 85,
-                category: 'ข้าวห่อหมกไข่ข้น | 咖喱滑蛋饭',
-                description: 'ข้าวหอมมะลิห่อด้วยไข่ข้นเนียนนุ่ม ท็อปด้วยห่อหมกหมึก รสเผ็ดกลมกล่อม กลิ่นแกงใต้หอมชวนกิน',
-                image: 'https://food-cms.grab.com/item/THITE20250607101831190487/photos/90d50de0edba452c9d64dbb617786a5f_1749291511138963222.jpeg',
-            },
-
-            // Category: ผลไม้พร้อมทาน | 鲜切水果
-            {
-                id: 'H10',
-                name: 'ผลไม้สดพร้อมทาน 4 ชนิด',
-                chineseName: '四种时令鲜果拼盘',
-                price: 59,
-                category: 'ผลไม้พร้อมทาน | 鲜切水果',
-                description: 'รวมผลไม้สดฉ่ำฉ่ำ 4 ชนิด จะเป็นผลไม้ตามฤดูกาล โดยผลไม้แต่ละวันจะแตกต่างกันไป',
-                image: 'https://food-cms.grab.com/item/THITE20250607101831216126/photos/menueditor_item_18a3a6f16efb4bd79be4d7b98d2f5c2f_1749292024418570039.jpg',
-            },
-            {
-                id: 'H20',
-                name: 'ส้มแมนดาริน',
-                chineseName: '鲜橘子',
-                price: 55,
-                category: 'ผลไม้พร้อมทาน | 鲜切水果',
-                description: 'ส้มแมนดาริน สดๆ สะอาด ปอกให้พร้อมทาน',
-                image: 'https://food-cms.grab.com/item/THITE20250607101831246086/photos/menueditor_item_a9580fa2ada142faac6d223b3d4b3b64_1749291856673071005.jpg',
-            },
-            {
-                id: 'H30',
-                name: 'แตงโม',
-                chineseName: '鲜西瓜',
-                price: 55,
-                category: 'ผลไม้พร้อมทาน | 鲜切水果',
-                description: 'แตงโม อร่อย ฉ่ำ ปอกพร้อมทาน',
-                image: 'https://food-cms.grab.com/item/THITE20250607101831238923/photos/menueditor_item_39b7461e42ff4e87a4134fe63061f934_1749291912589335319.jpg',
-            },
-            {
-                id: 'H40',
-                name: 'แอปเปิ้ล',
-                chineseName: '鲜苹果',
-                price: 55,
-                category: 'ผลไม้พร้อมทาน | 鲜切水果',
-                description: 'แอปเปิ้ลสด สีสันสวยงาม หวานกรอบพร้อมทาน',
-                image: 'https://food-cms.grab.com/item/THITE20250607101831221627/photos/menueditor_item_6d29a27014164ed2a2fc11ae95a9d4e1_1749291967774949322.jpg',
-            },
-            {
-                id: 'H50',
-                name: 'ฝรั่งกิมจู',
-                chineseName: '鲜芭乐 (青)',
-                price: 55,
-                category: 'ผลไม้พร้อมทาน | 鲜切水果',
-                description: 'ฝรั่งกิมจูสดๆ กรอบ อร่อย ปอกพร้อมทาน',
-                image: 'https://food-cms.grab.com/item/THITE20250607101831250967/photos/menueditor_item_c283b76ac5944f728eb51b76fcebdaff_1749291786310643903.jpg',
-            },
-            {
-                id: 'H60',
-                name: 'แก้วมังกร',
-                chineseName: '鲜火龙果',
-                price: 55,
-                category: 'ผลไม้พร้อมทาน | 鲜切水果',
-                description: 'แก้วมังกรสด หวานฉ่ำ พร้อมทานสะดวก',
-                image: 'https://food-cms.grab.com/compressed_webp/items/THITE2025060818192913160/detail/menueditor_item_9409b16462414e56b2120e5f31f2bdb2_1749406669988455989.webp', // Placeholder
-            },
-
-            // Category: เครื่องดื่ม | 饮品
-            {
-                id: 'D01',
-                name: 'น้ำเก๊กฮวย',
-                chineseName: '菊花茶',
-                price: 'ยังไม่พร้อมจำหน่าย',
-                category: 'เครื่องดื่ม | 饮品',
-                description: 'น้ำเก๊กฮวยหอมชื่นใจ ดับกระหาย',
-                image: 'https://placehold.co/280x160/F3F4F6/9CA3AF?text=Chrysanthemum+Tea', // Placeholder
-            },
-            {
-                id: 'D02',
-                name: 'ชาเขียว',
-                chineseName: '绿奶茶',
-                price: 'ยังไม่พร้อมจำหน่าย',
-                category: 'เครื่องดื่ม | 饮品',
-                description: 'ชาเขียวรสกลมกล่อม หอมสดชื่น',
-                image: 'https://placehold.co/280x160/F3F4F6/9CA3AF?text=Green+Tea', // Placeholder
-            },
-            {
-                id: 'D03',
-                name: 'ชาไทย',
-                chineseName: '泰式奶茶',
-                price: 'ยังไม่พร้อมจำหน่าย',
-                category: 'เครื่องดื่ม | 饮品',
-                description: 'ชาไทยรสชาติเข้มข้น หอมหวาน ชื่นใจ',
-                image: 'https://placehold.co/280x160/F3F4F6/9CA3AF?text=Thai+Tea', // Placeholder
-            },
-            {
-                id: 'D04',
-                name: 'น้ำกะเจียบ',
-                chineseName: '洛神花茶',
-                price: 'ยังไม่พร้อมจำหน่าย',
-                category: 'เครื่องดื่ม | 饮品',
-                description: 'น้ำกะเจียบหอมกลิ่นดอกไม้ ดื่มแล้วสดชื่น',
-                image: 'https://placehold.co/280x160/F3F4F6/9CA3AF?text=Roselle+Juice', // Placeholder
-            }
-        ];
-
-        const toppings = [
-            { name: 'ไข่ดาว', price: 10 },
-            { name: 'ไข่เจียว', price: 10 },
-            { name: 'ไข่ข้น สองฟอง', price: 20 },
-        ];
-
-        let searchTerm = '';
-        const order = [];
-        let currentItemId = null;
+    document.addEventListener('DOMContentLoaded', () => {
+        fetch('/api/menu-items')
+            .then(res => res.json())
+            .then(data => {
+                menuItems = data;
+                displayMenuSections();
+            });
+        updateOrderButton();
+    });
 
         function updateOrderButton() {
             const btn = document.getElementById('viewOrderBtn');
@@ -689,10 +405,6 @@
         }
 
         // Initial render when the page loads
-        document.addEventListener('DOMContentLoaded', () => {
-            displayMenuSections();
-            updateOrderButton();
-        });
     </script>
 </body>
 </html>

--- a/menu-items.json
+++ b/menu-items.json
@@ -1,0 +1,312 @@
+[
+  {
+    "id": "A10",
+    "name": "กะเพราหมูสับ",
+    "chineseName": "打拋猪肉末飯",
+    "price": 60,
+    "category": "กะเพรา | 打抛饭",
+    "description": "หมูสับผัดร้อนกับพริกและกระเพรา รสชาติจัดจ้าน หอมกลิ่นกระเพรา",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829081858/photos/90c609683c5746bbb33c07d09e706a0b_1749291509094445301.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "A20",
+    "name": "กะเพราหมูชิ้น",
+    "chineseName": "打拋猪肉片飯",
+    "price": 60,
+    "category": "กะเพรา | 打抛饭",
+    "description": "หมูชิ้นสไลซ์หนา ผัดกับพริกขี้หนูและกระเพรา เพิ่มรสเผ็ดร้อนเค็มกลมกล่อม",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101828075733/photos/a1c15920c62744bb87f0add8dc9b240b_1749291508901628367.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "A30",
+    "name": "กะเพราเนื้อสับ ดรายเอจพรีเมียม",
+    "chineseName": "优质干式熟成罗勒牛肉碎",
+    "price": 99,
+    "category": "กะเพรา | 打抛饭",
+    "description": "กะเพราเนื้อสับ ดรายเอจพรีเมียม รสเข้มข้น ให้รสชาติเนื้อเนียน ๆ ผสานความเผ็ดร้อนและกลิ่นหอมของใบกะเพรา",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829098489/photos/3304eaf7086c44ca8160d9a35e1bdb7c_1749291509277542087.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "A40",
+    "name": "กะเพรากุ้ง",
+    "chineseName": "打拋虾仁飯",
+    "price": 65,
+    "category": "กะเพรา | 打拋饭",
+    "description": "กุ้งสดเด้งผัดกับพริกขี้หนูและกระเพรา มอบรสเผ็ดร้อนและกลิ่นหอมของสมุนไพรไทย",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829103154/photos/e50bc49d0bad4c69b45aa0930583e692_1749291509433736279.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "A50",
+    "name": "กะเพราหมึก",
+    "chineseName": "打拋鱿鱼飯",
+    "price": 65,
+    "category": "กะเพรา | 打抛饭",
+    "description": "หมึกสดกรอบผัดกระเพรารสจัด ราดด้วยน้ำมันหอยเล็กน้อย เพิ่มรสกลมกล่อมและความหอมของกระเพรา",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829112940/photos/cf4cac4a97404815b6f68d57a716dcdb_1749291509586307764.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "A60",
+    "name": "กะเพราทะเลรวม",
+    "chineseName": "打拋海鮮飯",
+    "price": 65,
+    "category": "กะเพรา | 打抛饭",
+    "description": "รวมซีฟู้ดสด ทั้งกุ้ง หมึก และหอย ปรุงรสเข้มข้นกับพริกและกระเพรา ให้รสชาติทะเลหอมกรุ่น",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101829120496/photos/a537449c0c79412a9446f4dc938e1724_1749291509766172777.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "B10",
+    "name": "สปาเก็ตตี้กะเพราหมูสับ",
+    "chineseName": "蒜蓉猪肉末意面",
+    "price": 129,
+    "category": "สปาเก็ตตี้กะเพรา | 蒜蓉炒意面",
+    "description": "เส้นสปาเก็ตตี้ผัดกับหมูสับและกระเพรา รสจัด เผ็ดร้อน เคล้ากลิ่นหอมของสมุนไพร",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830142460/photos/c2358496f1f44fa99d8ef8fec16e70c6_1749291510140832547.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "B20",
+    "name": "สปาเก็ตตี้กะเพราเบคอน",
+    "chineseName": "蒜蓉培根意面",
+    "price": 139,
+    "category": "สปาเก็ตตี้กะเพรา | 蒜蓉炒意面",
+    "description": "สปาเก็ตตี้เส้นเหนียวนุ่ม ผัดกับเบคอนกรอบพริกขี้หนูและใบกะเพรา รสจัดจ้านกลมกล่อม",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830136048/photos/c5c13942080f4163933307f52a24b219_1749291510017200586.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "B30",
+    "name": "สปาเก็ตตี้กะเพราเนื้อสับ",
+    "chineseName": "牛肉蒜蓉意大利面",
+    "price": 139,
+    "category": "สปาเก็ตตี้กะเพรา | 蒜蓉炒意面",
+    "description": "เส้นสปาเก็ตตี้ผัดกับเนื้อสับพริกขี้หนูและกระเพรา มอบรสจัดจ้านและกลิ่นหอมของสมุนไพรไทย",
+    "image": "https://food-cms.grab.com/compressed_webp/items/THITE2025060818072098264/detail/menueditor_item_613b0d3e16594075b7d491c80468f182_1749405805842677085.webp",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "B40",
+    "name": "สปาเก็ตตี้กะเพรากุ้ง",
+    "chineseName": "蒜蓉虾仁意面",
+    "price": 139,
+    "category": "สปาเก็ตตี้กะเพรา | 蒜蓉炒意面",
+    "description": "เส้นสปาเก็ตตี้ผัดกับกุ้งสดพริกขี้หนูและกระเพรา มอบรสจัดจ้านและกลิ่นหอมทะเล",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830155451/photos/3ec3d4b3b22f47c09c9c03317276e98e_1749291510388832728.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "B50",
+    "name": "สปาเก็ตตี้กะเพราหมึก",
+    "chineseName": "蒜蓉鱿鱼意面",
+    "price": 139,
+    "category": "สปาเก็ตตี้กะเพรา | 蒜蓉炒意面",
+    "description": "สปาเก็ตตี้คลุกเคล้ากับหมึกสดและกระเพรา รสจัดจ้าน หวานนิดเค็มหน่อย กลิ่นหอมสมุนไพร",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830162409/photos/38258fab3cb74ebaa3299207a82d771a_1749291510584447361.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "B60",
+    "name": "สปาเก็ตตี้กะเพราทะเลรวม",
+    "chineseName": "蒜蓉海鲜意面",
+    "price": 139,
+    "category": "สปาเก็ตตี้กะเพรา | 蒜蓉炒意面",
+    "description": "สปาเก็ตตี้รวมซีฟู้ด ผัดกะเพรารสจัด เคล้ากลิ่นหอมทะเลและใบกะเพรา",
+    "image": "https://d1sag4ddilekf6.cloudfront.net/item/THITE20250607101830178652/photos/5a329a1bfb644082a5daaf70f56c6b95_1749291510756808485.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "C10",
+    "name": "ข้าวไข่ข้นหมูชิ้นทอดกระเทียม",
+    "chineseName": "蒜蓉滑蛋配香脆猪肉片",
+    "price": 79,
+    "category": "ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭",
+    "description": "ข้าวหอมมะลิ นุ่มราดด้วยไข่ข้นเนียน ๆ ท็อปด้วยหมูชิ้นทอดกรอบ ราดด้วยกระเทียมเจียวหอม ๆ ให้รสกลมกล่อมลงตัว",
+    "image": "https://food-cms.grab.com/item/THITE20250607101827015838/photos/5cb10df83786464b9991a95331cf22a6_1749291507846057663.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "C20",
+    "name": "ข้าวไข่ข้นหมูสับทอดกระเทียม",
+    "chineseName": "蒜蓉滑蛋配猪肉末",
+    "price": 79,
+    "category": "ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭",
+    "description": "ข้าวหอมมะลิ่นุ่มราดไข่ข้นลื่นกลมกล่อม เสิร์ฟพร้อมหมูสับทอดกระเทียมหอมกรอบ เพิ่มมิติความอร่อย",
+    "image": "https://food-cms.grab.com/item/THITE20250607101827023617/photos/4918d7e8f5e74775be9ad61febd36ce9_1749291508000517172.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "C30",
+    "name": "ข้าวไข่ข้นสามชั้นทอดกระเทียม",
+    "chineseName": "蒜蓉滑蛋配五花肉",
+    "price": 85,
+    "category": "ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭",
+    "description": "ข้าวหอมมะลิร้อน ๆ ราดไข่ข้นเนียนนุ่ม พร้อมสามชั้นหมูทอดกระเทียมกรอบมัน ผสมผสานรสเค็มหวานอย่างลงตัว",
+    "image": "https://food-cms.grab.com/item/THITE20250607101828030835/photos/f839283ea70146cd9df90660a0602395_1749291508172427363.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "C40",
+    "name": "ข้าวไข่ข้นเบคอนทอดกระเทียม",
+    "chineseName": "蒜蓉滑蛋配培根",
+    "price": 85,
+    "category": "ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭",
+    "description": "ไข่ข้นเนื้อเนียนราดบนข้าวหอมมะลิ เสิร์ฟพร้อมเบคอนทอดกรอบ ราดกระเทียมเจียวหอมฉุย",
+    "image": "https://food-cms.grab.com/item/THITE20250607101828047027/photos/e67d20f2366e4fe09065b6651b8426a7_1749291508291199328.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "C50",
+    "name": "ข้าวไข่ข้นกุ้งทอดกระเทียม",
+    "chineseName": "蒜蓉滑蛋配虾仁",
+    "price": 85,
+    "category": "ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭",
+    "description": "ไข่ข้นเนียนลื่นผสานบนข้าวหอมมะลิ เสิร์ฟพร้อมกุ้งทอดกระเทียม ให้รสชาติหวานมันเค็มกรอบอย่างลงตัว",
+    "image": "https://food-cms.grab.com/item/THITE20250607101828059916/photos/64b3a1c4348c48acad1c5bef0602b09c_1749291508460521618.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "C60",
+    "name": "ข้าวไข่ข้นหมึกทอดกระเทียม",
+    "chineseName": "蒜蓉滑蛋配鱿鱼",
+    "price": 85,
+    "category": "ข้าวไข่ข้น ทอดกระเทียม | 蒜蓉滑蛋饭",
+    "description": "ข้าวหอมมะลิร้อน ๆ กับไข่ข้นเนียนนุ่ม ท็อปด้วยหมึกทอดกระเทียมหอมกรอบ มอบประสบการณ์รสชาติใหม่",
+    "image": "https://food-cms.grab.com/compressed_webp/items/THITE20250607101828064013/detail/d20f4774f46c4aefa51fce242bee0f80_1749291508736290122.webp",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "E10",
+    "name": "ข้าวห่อหมกไข่ข้นทะเล",
+    "chineseName": "咖喱滑蛋配海鲜咖喱饭",
+    "price": 85,
+    "category": "ข้าวห่อหมกไข่ข้น | 咖喱滑蛋饭",
+    "description": "ข้าวหอมมะลิห่อด้วยไข่ข้น สอดไส้ทะเลรวม หวานมัน เผ็ดกลมกล่อม ได้กลิ่นเครื่องแกงใต้",
+    "image": "https://food-cms.grab.com/item/THITE20250607101831205466/photos/fd78335aab7d47f786e53bf3d46bbe8f_1749291511304272485.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "E20",
+    "name": "ข้าวห่อหมกไข่ข้นกุ้ง",
+    "chineseName": "咖喱滑蛋配虾仁咖喱饭",
+    "price": 85,
+    "category": "ข้าวห่อหมกไข่ข้น | 咖喱滑蛋饭",
+    "description": "ข้าวหอมมะลิห่อด้วยไข่ข้นห่อด้วยไข่ข้นรสเข้ม เสิร์ฟพร้อมห่อหมกกุ้งเนื้อแน่น เผ็ดนิด ๆ หวานมัน",
+    "image": "https://food-cms.grab.com/item/THITE20250607101830184557/photos/73a40c4bbd5c4ee29db93587ec2cac7a_1749291510941373744.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "E30",
+    "name": "ข้าวห่อหมกไข่ข้นหมึก",
+    "chineseName": "咖喱滑蛋配鱿鱼咖喱饭",
+    "price": 85,
+    "category": "ข้าวห่อหมกไข่ข้น | 咖喱滑蛋饭",
+    "description": "ข้าวหอมมะลิห่อด้วยไข่ข้นเนียนนุ่ม ท็อปด้วยห่อหมกหมึก รสเผ็ดกลมกล่อม กลิ่นแกงใต้หอมชวนกิน",
+    "image": "https://food-cms.grab.com/item/THITE20250607101831190487/photos/90d50de0edba452c9d64dbb617786a5f_1749291511138963222.jpeg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "H10",
+    "name": "ผลไม้สดพร้อมทาน 4 ชนิด",
+    "chineseName": "四种时令鲜果拼盘",
+    "price": 59,
+    "category": "ผลไม้พร้อมทาน | 鲜切水果",
+    "description": "รวมผลไม้สดฉ่ำฉ่ำ 4 ชนิด จะเป็นผลไม้ตามฤดูกาล โดยผลไม้แต่ละวันจะแตกต่างกันไป",
+    "image": "https://food-cms.grab.com/item/THITE20250607101831216126/photos/menueditor_item_18a3a6f16efb4bd79be4d7b98d2f5c2f_1749292024418570039.jpg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "H20",
+    "name": "ส้มแมนดาริน",
+    "chineseName": "鲜橘子",
+    "price": 55,
+    "category": "ผลไม้พร้อมทาน | 鲜切水果",
+    "description": "ส้มแมนดาริน สดๆ สะอาด ปอกให้พร้อมทาน",
+    "image": "https://food-cms.grab.com/item/THITE20250607101831246086/photos/menueditor_item_a9580fa2ada142faac6d223b3d4b3b64_1749291856673071005.jpg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "H30",
+    "name": "แตงโม",
+    "chineseName": "鲜西瓜",
+    "price": 55,
+    "category": "ผลไม้พร้อมทาน | 鲜切水果",
+    "description": "แตงโม อร่อย ฉ่ำ ปอกพร้อมทาน",
+    "image": "https://food-cms.grab.com/item/THITE20250607101831238923/photos/menueditor_item_39b7461e42ff4e87a4134fe63061f934_1749291912589335319.jpg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "H40",
+    "name": "แอปเปิ้ล",
+    "chineseName": "鲜苹果",
+    "price": 55,
+    "category": "ผลไม้พร้อมทาน | 鲜切水果",
+    "description": "แอปเปิ้ลสด สีสันสวยงาม หวานกรอบพร้อมทาน",
+    "image": "https://food-cms.grab.com/item/THITE20250607101831221627/photos/menueditor_item_6d29a27014164ed2a2fc11ae95a9d4e1_1749291967774949322.jpg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "H50",
+    "name": "ฝรั่งกิมจู",
+    "chineseName": "鲜芭乐 (青)",
+    "price": 55,
+    "category": "ผลไม้พร้อมทาน | 鲜切水果",
+    "description": "ฝรั่งกิมจูสดๆ กรอบ อร่อย ปอกพร้อมทาน",
+    "image": "https://food-cms.grab.com/item/THITE20250607101831250967/photos/menueditor_item_c283b76ac5944f728eb51b76fcebdaff_1749291786310643903.jpg",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "H60",
+    "name": "แก้วมังกร",
+    "chineseName": "鲜火龙果",
+    "price": 55,
+    "category": "ผลไม้พร้อมทาน | 鲜切水果",
+    "description": "แก้วมังกรสด หวานฉ่ำ พร้อมทานสะดวก",
+    "image": "https://food-cms.grab.com/compressed_webp/items/THITE2025060818192913160/detail/menueditor_item_9409b16462414e56b2120e5f31f2bdb2_1749406669988455989.webp",
+    "status": "พร้อมจำหน่าย"
+  },
+  {
+    "id": "D01",
+    "name": "น้ำเก๊กฮวย",
+    "chineseName": "菊花茶",
+    "price": "ยังไม่พร้อมจำหน่าย",
+    "category": "เครื่องดื่ม | 饮品",
+    "description": "น้ำเก๊กฮวยหอมชื่นใจ ดับกระหาย",
+    "image": "https://placehold.co/280x160/F3F4F6/9CA3AF?text=Chrysanthemum+Tea",
+    "status": "ยังไม่พร้อมจำหน่าย"
+  },
+  {
+    "id": "D02",
+    "name": "ชาเขียว",
+    "chineseName": "绿奶茶",
+    "price": "ยังไม่พร้อมจำหน่าย",
+    "category": "เครื่องดื่ม | 饮品",
+    "description": "ชาเขียวรสกลมกล่อม หอมสดชื่น",
+    "image": "https://placehold.co/280x160/F3F4F6/9CA3AF?text=Green+Tea",
+    "status": "ยังไม่พร้อมจำหน่าย"
+  },
+  {
+    "id": "D03",
+    "name": "ชาไทย",
+    "chineseName": "泰式奶茶",
+    "price": "ยังไม่พร้อมจำหน่าย",
+    "category": "เครื่องดื่ม | 饮品",
+    "description": "ชาไทยรสชาติเข้มข้น หอมหวาน ชื่นใจ",
+    "image": "https://placehold.co/280x160/F3F4F6/9CA3AF?text=Thai+Tea",
+    "status": "ยังไม่พร้อมจำหน่าย"
+  },
+  {
+    "id": "D04",
+    "name": "น้ำกะเจียบ",
+    "chineseName": "洛神花茶",
+    "price": "ยังไม่พร้อมจำหน่าย",
+    "category": "เครื่องดื่ม | 饮品",
+    "description": "น้ำกะเจียบหอมกลิ่นดอกไม้ ดื่มแล้วสดชื่น",
+    "image": "https://placehold.co/280x160/F3F4F6/9CA3AF?text=Roselle+Juice",
+    "status": "ยังไม่พร้อมจำหน่าย"
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,860 @@
+{
+  "name": "webmenu",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "webmenu",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2",
+        "express-basic-auth": "^1.2.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-basic-auth": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
+      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "webmenu",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-basic-auth": "^1.2.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const basicAuth = require('express-basic-auth');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const DATA_FILE = path.join(__dirname, 'menu-items.json');
+const PORT = process.env.PORT || 3000;
+const ADMIN_PASS = process.env.ADMIN_PASS || 'changeme';
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+function readData() {
+  return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+}
+
+function writeData(data) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+app.get('/api/menu-items', (req, res) => {
+  res.json(readData());
+});
+
+const adminAuth = basicAuth({
+  users: { admin: ADMIN_PASS },
+  challenge: true
+});
+
+app.get('/admin', adminAuth, (req, res) => {
+  res.sendFile(path.join(__dirname, 'admin.html'));
+});
+
+app.post('/api/menu-items/:id', adminAuth, (req, res) => {
+  const data = readData();
+  const item = data.find(i => i.id === req.params.id);
+  if (!item) {
+    return res.status(404).json({ error: 'Item not found' });
+  }
+  Object.assign(item, req.body);
+  writeData(data);
+  res.json(item);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server with basic-auth protected admin API
- convert menu items to JSON file and load via fetch
- create admin panel for editing menu items
- document how to run the server

## Testing
- `npm install`
- `npm start` (server runs)
- `curl -u admin:changeme http://localhost:3000/admin` returns admin page

------
https://chatgpt.com/codex/tasks/task_e_684ee53e887c8329abd866409c438abb